### PR TITLE
chore(ci): enforce sovereign CI baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+﻿name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "CI OK"


### PR DESCRIPTION
Adds/standardizes a minimal CI workflow for baseline validation.